### PR TITLE
Handle query based attenutation.

### DIFF
--- a/lib/ZcapClient.js
+++ b/lib/ZcapClient.js
@@ -347,6 +347,7 @@ export class ZcapClient {
       // confused deputy (don't invoke zcaps against URLs that are in different
       // authority heirarchies)
       if(!(url.startsWith(invocationTarget + '/') ||
+        url.startsWith(invocationTarget + '?') ||
         url === invocationTarget)) {
         throw new TypeError(
           `When "url" and "capability" are both given, the capability's ` +


### PR DESCRIPTION
Using this version of the spec as a reference: https://w3c-ccg.github.io/zcap-spec/#delegated-capability-attenuation

Handles cases such as this:
```
invocationTarget: 'https://www.test.com/zcap'
requestUrl: 'https://www.test.com/zcap?foo=bar'
```