### PR TITLE
Add blob option to zcapClient.request() and update unit test

### DIFF
--- a/lib/ZcapClient.js
+++ b/lib/ZcapClient.js
@@ -289,8 +289,10 @@ export class ZcapClient {
    *   invoked. Default: 'read'.
    * @param {object} [options.headers] - The additional headers to sign and
    *   send along with the HTTP request. Default: {}.
-   * @param {object} options.json - The JSON object, if any, to send with the
+   * @param {object} [options.json] - The JSON object, if any, to send with the
    *   request.
+   * @param {Blob|Buffer|Uint8Array} [options.blob] - The binary blob to send
+   *   with the request (for file uploads, PDFs, images, etc.).
    *
    * @returns {Promise<object>} - A promise that resolves to an HTTP response.
    */
@@ -300,7 +302,8 @@ export class ZcapClient {
     method = 'get',
     action = 'read',
     headers = {},
-    json
+    json,
+    blob
   } = {}) {
     if(!this.invocationSigner) {
       throw new Error('"invocationSigner" was not provided in constructor.');
@@ -375,10 +378,16 @@ export class ZcapClient {
     // build the final request
     const options = {
       method,
-      json,
       agent,
       headers: {...this.defaultHeaders, ...signatureHeaders}
     };
+
+    // handle blob vs json body
+    if(blob !== undefined) {
+      options.body = blob;
+    } else if(json !== undefined) {
+      options.json = json;
+    }
 
     return httpClient(url, options);
   }

--- a/tests/unit/EzcapClient.spec.js
+++ b/tests/unit/EzcapClient.spec.js
@@ -141,4 +141,96 @@ describe('ZcapClient', () => {
       }
     });
   });
+
+  describe('ZcapClient.request', () => {
+    it('should accept blob parameter without throwing', async () => {
+      const {didDocument, keyPairs} = await didKeyDriver.generate();
+      const {invocationSigner} = getCapabilitySigners({didDocument, keyPairs});
+      const zcapClient = new ZcapClient({
+        SuiteClass: Ed25519Signature2020,
+        invocationSigner
+      });
+
+      const blob = Buffer.from('hello world');
+
+      // Test that the method accepts blob parameter without throwing
+      // This will fail at HTTP level, but we're testing the method signature
+      let error;
+      try {
+        await zcapClient.request({
+          url: 'https://zcap.example/items',
+          method: 'post',
+          blob
+        });
+      } catch(e) {
+        error = e;
+      }
+
+      // Should not throw a parameter validation error
+      // HTTP errors are expected since we're not mocking
+      expect(error).to.exist;
+      expect(error.message).to.not.include('blob');
+      expect(error.message).to.not.include('parameter');
+      expect(error.message).to.not.include('undefined');
+    });
+
+    it('should accept both json and blob parameters', async () => {
+      const {didDocument, keyPairs} = await didKeyDriver.generate();
+      const {invocationSigner} = getCapabilitySigners({didDocument, keyPairs});
+      const zcapClient = new ZcapClient({
+        SuiteClass: Ed25519Signature2020,
+        invocationSigner
+      });
+
+      const blob = Buffer.from('hello world');
+      const json = {message: 'test'};
+
+      // Test that the method accepts both parameters without throwing
+      let error;
+      try {
+        await zcapClient.request({
+          url: 'https://zcap.example/items',
+          method: 'post',
+          json,
+          blob
+        });
+      } catch(e) {
+        error = e;
+      }
+
+      // Should not throw a parameter validation error
+      expect(error).to.exist;
+      expect(error.message).to.not.include('blob');
+      expect(error.message).to.not.include('json');
+      expect(error.message).to.not.include('parameter');
+    });
+
+    it('should accept blob parameter in write method', async () => {
+      const {didDocument, keyPairs} = await didKeyDriver.generate();
+      const {invocationSigner} = getCapabilitySigners({didDocument, keyPairs});
+      const zcapClient = new ZcapClient({
+        SuiteClass: Ed25519Signature2020,
+        invocationSigner
+      });
+
+      const blob = Buffer.from('hello world');
+
+      // Test that the write method accepts blob parameter without throwing
+      let error;
+      try {
+        await zcapClient.write({
+          url: 'https://zcap.example/items',
+          blob
+        });
+      } catch(e) {
+        error = e;
+      }
+
+      // Should not throw a parameter validation error
+      expect(error).to.exist;
+      expect(error.message).to.not.include('blob');
+      expect(error.message).to.not.include('parameter');
+      expect(error.message).to.not.include('undefined');
+    });
+  });
 });


### PR DESCRIPTION
Updates the `request()` method to also support binary Blob objects in request body (in addition to just JSON object).